### PR TITLE
Added removal of non-primary reads to both pipelines

### DIFF
--- a/hisat2_pipeline.sh
+++ b/hisat2_pipeline.sh
@@ -96,7 +96,7 @@ echo "Mapping reads to the reference genome using Hisat2."
 hisat2 --no-spliced-alignment -p $nThreads -q -x $assemblyID -1 ../fastq/${CloneID}_R1-paired.fastq -2 ../fastq/${CloneID}_R2-paired.fastq -S ../fastq/${CloneID}_${assemblyID}.sam
 
 # 4. Convert the SAM file to the BAM file.
-echo "Converting the sam file to bam."
+echo "Converting the sam file to bam and removing non-primary alignments."
 cd ../fastq
 samtools view -b -F 256 ${CloneID}_${assemblyID}.sam > ${CloneID}_${assemblyID}.bam 
 

--- a/original_batch_novoalign.sh
+++ b/original_batch_novoalign.sh
@@ -10,6 +10,6 @@ WD=/N/u/rtraborn/Carbonate/scratch/DaphniaVariantCall
 
 cd $WD
 
-time ./original_pipeline.sh
+time ./original_pipeline_novoalign.sh
 
 exit


### PR DESCRIPTION
Other changes include:

- move to samtools 1.5 via `module load samtools` on carbonate
-minor name change to pipeline containing novoalign (now called `original_pipeline_novoalign.sh`)
- switch to updated version of assembly by default (PA42 v. 4)

Note: Hisat2 pipeline is roughly 2x faster than novoalign using 8 threads.